### PR TITLE
[2024/01/04] 전성태

### DIFF
--- a/전성태/백준/재귀/1074_2.js
+++ b/전성태/백준/재귀/1074_2.js
@@ -1,0 +1,43 @@
+function recur(x, y, length){
+    if(length === 1){
+        if(x === c && y === r){
+            console.log(ans)
+            return
+        }
+        return
+    }
+
+    let half = length / 2
+    if((x <= c && c < x + half) && (y <= r && r < y + half)){
+        recur(x, y, half)
+    } else{
+        ans += half * half
+    }
+
+    if((x + half <= c && c < x + length) && (y <= r && r < y + half)){
+        recur(x + half, y, half)
+    } else{
+        ans += half * half
+    }
+
+    if((x <= c && c < x + half) && (y + half <= r && r < y + length)){
+        recur(x, y + half, half)
+    } else{
+        ans += half * half
+    }
+
+    if((x + half <= c && c < x + length) && (y + half <= r && r < y + length)){
+        recur(x + half, y + half, half)
+    } else{
+        ans += half * half
+    }
+
+}
+
+const input = require('fs').readFileSync('/dev/stdin').toString().split('\n')
+const inpArr = input[0].split(' ')
+const n = parseInt(inpArr[0])
+const r = parseInt(inpArr[1])
+const c = parseInt(inpArr[2])
+let ans = 0
+recur(0,0,2**n)

--- a/전성태/백준/정렬/2751.js
+++ b/전성태/백준/정렬/2751.js
@@ -1,0 +1,9 @@
+const input = require('fs').readFileSync('/dev/stdin').toString().split('\n')
+const N = parseInt(input[0])
+const numArr = []
+for(let i = 1; i <= N; i++){
+    numArr.push(parseInt(input[i]))
+}
+
+numArr.sort((a,b)=>a - b)
+console.log(numArr.join('\n'))


### PR DESCRIPTION
1. Z 안보고 다시 풀어봄
2. 수 정렬하기 풀어봄
- js에서 배열을 출력할 때 반복문으로 console.log 를 하는 방식은 매우 느리다.
- 따라서 console.log(array.join('\n'))으로 출력해야 한다.
- 참고로 join의 시간 복잡도는 O(n) 이다.