### PR TITLE
[2024/01/11] 전성태

### DIFF
--- a/전성태/백준/완전탐색/2798.js
+++ b/전성태/백준/완전탐색/2798.js
@@ -1,0 +1,27 @@
+function recur(idx){
+    let sum = ans.reduce((prev,cur)=>prev+cur,0)
+    if(sum > M) return
+    else if(ans.length === 3){
+        sums.push(sum)
+        return
+    }
+
+    for(let i = idx; i < intNumArr.length; i++){
+        ans.push(intNumArr[i])
+        recur(i + 1)
+        ans.pop()
+    }
+
+}
+
+const input = require('fs').readFileSync('/dev/stdin').toString().split('\n')
+const N = parseInt(input[0].split(' ')[0])
+const M = parseInt(input[0].split(' ')[1])
+const numArr = input[1].split(' ')
+const intNumArr = numArr.map((num)=>parseInt(num,10))
+const ans = []
+const sums = []
+recur(0)
+console.log(sums.reduce((prev,cur)=>{
+    return prev > cur ? prev : cur
+}))


### PR DESCRIPTION
# 블랙잭
- 3중 반복문으로 푸는 방법 대신 재귀로 완탐하여 풀었다.
- 배열 안에 있는 모든 요소가 string 일 때 전부 int로 바꾸는 방법은 map을 이용하면 된다.
  - ```numArr.map((num)=>parseInt(num,10))```
  - 이 때, parseInt 의 두번째 인자로는 몇진수 인지가 들어가며, 10진수가 기본이 아니랜다.
- 파이썬의 max를 js에서도 `Math.max.apply(null, 배열); // 최대값` 이렇게 쓸 순 있지만 메모리를 더 효율적으로 쓰기 위한 방법은 reduce를 이용하는 방법이다.
 
 ```
  sums.reduce((prev,cur)=>{
    return prev > cur ? prev : cur
})
```