### PR TITLE
[2024/01/23] 전성태

### DIFF
--- a/전성태/백준/이분 탐색/2470_binarySearch.js
+++ b/전성태/백준/이분 탐색/2470_binarySearch.js
@@ -1,22 +1,26 @@
-function recur(start, end){
-    if(start >= end) return
+// 이분탐색 이용
 
-    let inner_gap = arr[end] + arr[start]
+function recur(start, end, num){
+    if(start > end) return
+
+    let middle = ~~((start + end)/2)
+
+    let inner_gap = num + arr[middle]
     let abs_inner_gap = inner_gap < 0 ? -1n * inner_gap : inner_gap
     
     if(abs_inner_gap < ans){
         ans = abs_inner_gap
-        ansStart = start
-        ansEnd = end
+        ansStart = num
+        ansEnd = arr[middle]
     }
     
     if(inner_gap === 0){
         return
     }
     else if(inner_gap > 0){
-        recur(start, end - 1)
+        recur(start, middle - 1,num)
     } else {
-        recur(start + 1, end)
+        recur(middle + 1, end,num)
     }
 }
 
@@ -31,6 +35,11 @@ arr.sort((a,b)=>{
 let ansStart = 0;
 let ansEnd = 0;
 let ans = 1_000_000_000_000n;
-recur(0, N-1)
+for(let i = 0; i < N; i++){
+    recur(i+1, N-1, arr[i])
+}
 
-console.log(arr[ansStart].toString(), arr[ansEnd].toString())
+console.log(ansStart.toString(), ansEnd.toString())
+
+// 시간 : 480 ms
+// 메모리 : 38644 KB

--- a/전성태/백준/이분 탐색/2470_twoPointer.js
+++ b/전성태/백준/이분 탐색/2470_twoPointer.js
@@ -1,0 +1,41 @@
+// 투포인터 이용
+
+function recur(start, end){
+    if(start >= end) return
+
+    let inner_gap = arr[end] + arr[start]
+    let abs_inner_gap = inner_gap < 0 ? -1n * inner_gap : inner_gap
+    
+    if(abs_inner_gap < ans){
+        ans = abs_inner_gap
+        ansStart = start
+        ansEnd = end
+    }
+    
+    if(inner_gap === 0){
+        return
+    }
+    else if(inner_gap > 0){
+        recur(start, end - 1)
+    } else {
+        recur(start + 1, end)
+    }
+}
+
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const N = parseInt(stdin[0])
+const arr = stdin[1].split(' ').map(BigInt)
+arr.sort((a,b)=>{
+    if(a-b>0) return 1
+    else if(a-b<0) return -1
+    else return 0
+})
+let ansStart = 0;
+let ansEnd = 0;
+let ans = 1_000_000_000_000n;
+recur(0, N-1)
+
+console.log(arr[ansStart].toString(), arr[ansEnd].toString())
+
+// 시간 : 304 ms
+// 메모리 : 45080 KB


### PR DESCRIPTION
# 투포인터 VS 이분탐색

\ | 이진탐색 | 투포인터
-- | -- | --
시간복잡도 | O(log n) | O(n)
기법 | mid를 지정하여 탐색 범위를 절반으로 탐색 | 문제에서 주어진 조건을 맞추는 방향양끝단 혹은 좌에서 우로 탐색
조건 | 데이터 정렬 sort 필요 | 필요 x, 있으면 좋음

# 두 용액
- 위 내용처럼 이진탐색이 투포인터보다 더 시간 복잡도가 낮다.
- 하지만 이분탐색으로 이 문제를 풀 경우 `모든 배열의 요소가 두 용액 중 하나일 때` 라는 모든 경우의 수를 다 이분 탐색으로 살펴본다.
  - 반복문 안에서 이분탐색을 호출하므로 O(n) X O(logN) 이다.
- 반면 투포인터는 반복문 없이 투포인터를 한 번만 실행하므로 시간 복잡도가 더 낮다.
  - O(n)