### PR TITLE
[2024/02/02] 전성태_스택_크게만들기

### DIFF
--- a/전성태/백준/스택/2812.js
+++ b/전성태/백준/스택/2812.js
@@ -1,0 +1,45 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const [N, K] = stdin[0].split(' ').map(Number)
+const nums = [...stdin[1]].map(Number)
+nums.reverse()
+let count = 0;
+let stack = []
+for(let i = 0; i < N; i++){
+    if(count === K) {
+        while(nums.length !== 0){
+            stack.push(nums.pop())
+        }
+        break
+    }
+    let popped = nums.pop()
+    if(stack.length === 0) {
+        stack.push(popped)
+        continue
+    }
+
+    if(popped > stack[stack.length-1]){
+        while(popped > stack[stack.length-1] && count !== K){
+            stack.pop()
+            count++
+        }
+        stack.push(popped)
+        continue
+    } else{
+        if(popped < nums[nums.length-1]){
+            count++
+            continue
+        } else {
+            stack.push(popped)
+        }
+    }
+
+}
+while(count !== K){
+    let poppop = stack.pop()
+    if(stack[stack.length-1] < poppop){
+        stack.pop()
+        stack.push(poppop)
+    }
+    count++
+}
+console.log(stack.join(''))


### PR DESCRIPTION
# 크게 만들기

- 문자열을 배열(arr)로 만든 뒤 뒤집에서 하나씩 pop해가면서 비교 후 stack에 다시 넣는 방식

  - 이때 비교를 2가지로 해줘야 함

    - arr에서 pop 한 것이 스택에 최상단보다 큰지. -> true라면 그렇지 않은게 나올때 까지 스택에서 pop 한 후 arr에서 pop한 것을 스택에 push & count 증가

    - 위 내용이 false 라면 arr에서 pop한 것이 이번엔 arr에서 다음에 pop 될 것 보다 작은지 확인 후 그렇다면 count를 증가시키고, 아니라면 스택에 Push

    - count가 K가 됐을 때 arr에 남아있는 것들 다 Stack에 Push 해주고 break

### 느낀점
- 반례가 많은 문제였다. 반례에 맞게 계속 코드를 수정했지만 코테에서는 이렇게 못 하겠지
- 그래도 답 안보고 풀어서 뿌듯하다

# 문자열을 배열로
- `const arr = [..."string"]`
- 간단한건데 몰랐다