### PR TITLE
[2024/02/04] 전성태_BFS_미로탐색

### DIFF
--- a/전성태/백준/BFS/2178.js
+++ b/전성태/백준/BFS/2178.js
@@ -1,0 +1,25 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const [N, M] = stdin[0].split(' ').map(Number)
+const graph = Array(N)
+for(let i = 0; i < N; i++){
+    graph[i] = stdin[i+1].split('').map(Number)
+}
+const queue = [[0,0]]
+const dx = [-1, 1, 0, 0] 
+const dy = [0, 0, -1, 1]
+while(queue.length !== 0){
+    let [y, x] = queue.shift()
+
+    for(let i = 0; i < 4; i++){
+        let nx = x + dx[i]
+        let ny = y + dy[i]
+
+        if(0 <= nx && nx < M && 0 <= ny && ny < N){
+            if(graph[ny][nx] === 1){
+                    queue.push([ny, nx])
+                    graph[ny][nx] = graph[y][x] + 1
+            }
+        }
+    }
+}
+console.log(graph[N-1][M-1].toString())


### PR DESCRIPTION
# 미로 탐색
- 첫 시도 때 queue 와 visited를 만들고 재귀적으로 bfs 를 적용하려고 했으나 이 문제는 오히려 반복문을 이용하면 visited도 쓸 필요 없고 더 간단했다.
- 그저 자신이 방문한 값에 +1만 해주면 그게 곧 visited가 되고, 그게 곧 최소 거리가 되었다.

# 그래프 탐색
```js
const dx = [-1, 1, 0, 0] 
const dy = [0, 0, -1, 1]

    for(let i = 0; i < 4; i++){ // 상하좌우 다 돌면서 
        let nx = x + dx[i]
        let ny = y + dy[i]

        if(0 <= nx && nx < M && 0 <= ny && ny < N){ // 범위 내에 있다면
        ... // 이후 할 동작 정의
```

이런식으로.