### PR TITLE
[2024/02/20] 김지성

### DIFF
--- a/김지성/백준/큐/18258.js
+++ b/김지성/백준/큐/18258.js
@@ -1,0 +1,86 @@
+// 큐 2
+const filePath = process.platform === "linux" ? "/dev/stdin" : "test.txt";
+const input = require("fs")
+  .readFileSync(filePath)
+  .toString()
+  .trim()
+  .split("\n");
+
+class Node {
+  constructor(data) {
+    this.data = data;
+    this.next = null;
+  }
+}
+
+class Queue {
+  constructor() {
+    this.head = null;
+    this.tail = null;
+    this.size = 0;
+  }
+
+  push(data) {
+    const newNode = new Node(data);
+    if (this.size === 0) {
+      this.head = newNode;
+      this.tail = newNode;
+    } else {
+      this.tail.next = newNode;
+      this.tail = newNode;
+    }
+    this.size++;
+  }
+
+  pop() {
+    if (this.size === 0) {
+      return -1;
+    }
+    const data = this.head.data;
+    this.head = this.head.next;
+    this.size--;
+    return data;
+  }
+
+  empty() {
+    return this.size === 0 ? 1 : 0;
+  }
+
+  front() {
+    return this.size === 0 ? -1 : this.head.data;
+  }
+
+  back() {
+    return this.size === 0 ? -1 : this.tail.data;
+  }
+}
+
+const queue = new Queue();
+let result = "";
+
+for (let i = 1; i <= input[0]; i++) {
+  const command = input[i].split(" ");
+
+  switch (command[0]) {
+    case "push":
+      queue.push(command[1]);
+      break;
+    case "pop":
+      result += queue.pop() + "\n";
+      break;
+    case "size":
+      result += queue.size + "\n";
+      break;
+    case "empty":
+      result += queue.empty() + "\n";
+      break;
+    case "front":
+      result += queue.front() + "\n";
+      break;
+    case "back":
+      result += queue.back() + "\n";
+      break;
+  }
+}
+
+console.log(result);

--- a/김지성/백준/큐/test.txt
+++ b/김지성/백준/큐/test.txt
@@ -1,0 +1,16 @@
+15
+push 1
+push 2
+front
+back
+size
+empty
+pop
+pop
+pop
+size
+empty
+pop
+push 3
+empty
+front


### PR DESCRIPTION
다름이 아니라 큐구현 문제풀면서 겪은 javascript 배열에 대해서 공유하고자 rq함

Array.shift() 함수를 사용하여 큐를 구현할 때, 
javascript를 밀집배열처럼 사용할 수 있도록 하기 위해서 배열의 제일 처음을 내보내고, 이후 값들을 한칸씩 앞으로 당기는 계산을 하기때문에 링크드리스트를 이용해서 큐의 pop을 구현하는게 일반 배열에서 Array.shift를 사용하는 것 보다 빠르다는 것이다.
이는 Array.pop()또한 포함되는 내용이다.

javascript에서 배열은 shift를 이용하지 않고 특정 값을 비우거나 삭제했을 때, 희소배열이 될 수 있기에 일어나는 일이라고 생각한다.

[추가자료](https://velog.io/@grap3fruit/JS-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EA%B5%AC%ED%98%84-%ED%81%90Queue-%EA%B5%AC%ED%98%84%ED%96%88%EC%9D%84%EB%95%8C-vs-Array-%EB%A9%94%EC%84%9C%EB%93%9Cshift-splice-%EC%82%AC%EC%9A%A9%ED%96%88%EC%9D%84%EB%95%8C-%EC%86%8D%EB%8F%84-%EB%B9%84%EA%B5%90)
