### PR TITLE
[2024-02-27] 최승현 Hash

### DIFF
--- a/최승현/leet/hash/2352.py
+++ b/최승현/leet/hash/2352.py
@@ -1,0 +1,37 @@
+"""
+https://leetcode.com/problems/equal-row-and-column-pairs
+
+Ri 행과 Cj 열이 같은 시퀀스를 갖도록 만드는 모든 i,j 쌍의 개수를 구하여라 
+"""
+
+from typing import List
+from collections import defaultdict
+
+
+class Solution:
+    def equalPairs(self, grid: List[List[int]]) -> int:
+        N = len(grid)
+        M = len(grid[0])
+
+        row_hashs = defaultdict(int)
+        col_hashs = defaultdict(int)
+
+        for i in range(N):
+            row_hashs[hash(tuple(grid[i][:]))] += 1
+        for j in range(M):
+            col_hashs[hash(tuple(grid[i][j] for i in range(N)))] += 1
+
+        result = 0
+
+        for key, count in row_hashs.items():
+            for _ in range(count):
+                result += col_hashs[key]
+
+        return result
+
+
+if __name__ == "__main__":
+    s = Solution()
+
+    print(s.equalPairs([[3, 2, 1], [1, 7, 6], [2, 7, 7]]))
+    print(s.equalPairs([[3, 1, 2, 2], [1, 4, 4, 5], [2, 4, 2, 2], [2, 4, 2, 2]]))


### PR DESCRIPTION
Ri 행과 Cj 열이 같은 시퀀스를 갖도록 만드는 모든 i, j 쌍의 개수를 구하는 문제. 예외처리가 살짝 힘들었다. 처음엔 각각의 행, 각각의 열을 내장 hash() 함수를 사용한 결과를 저장한 set 두개를 만들고, 행 해시 set을 순회하며 열 해시 set 안에 존재하는지 여부만 검사했었다. ===> 같은 시퀀스가 여러 행에 걸쳐 나오는 경우를 셀 수 없었음.

따라서, 카운팅을 위한 collections.defaultdict 객체를 사용하여 같은 해시값이 나왔을 경우 카운팅을 늘려주는 방식을 사용하였다. 같은 열에서도 같은 시퀀스가 나올 수 있기 때문에 단순 1씩만 더하는 것이 아닌, result += col_hashs[key] 하는 방식으로 문제를 해결했다.