### PR TITLE
[2024/03/03] 전성태_DFS_BFS

### DIFF
--- a/전성태/백준/그래프탐색기본/1260.js
+++ b/전성태/백준/그래프탐색기본/1260.js
@@ -1,0 +1,51 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const [N, M, V] = stdin[0].split(' ').map(Number)
+const graph = {}
+for(let i = 1; i <= M; i++){
+    let [a, b] = stdin[i].split(' ').map(Number)
+    if(typeof graph[a] !== 'object') graph[a] = Array()
+    if(!graph[a].includes(b))graph[a].push(b)
+    if(typeof graph[b] !== 'object') graph[b] = Array()
+    if(!graph[b].includes(a))graph[b].push(a)
+}
+
+for(let child in graph){
+    graph[child].sort((a,b)=>b-a)
+}
+
+const dfsExplored = []
+const stack = [V]
+while(stack.length !== 0){
+    let popped = stack.pop()
+    if(dfsExplored.includes(popped)) continue
+    dfsExplored.push(popped)
+    if(typeof graph[popped] !== 'object') continue
+
+    for(let i = 0; i < graph[popped].length; i++){
+        if(!dfsExplored.includes(graph[popped][i]))
+            stack.push(graph[popped][i])
+    }
+}
+
+console.log(dfsExplored.join(' '))
+
+for(let child in graph){
+    graph[child].sort((a,b)=>a-b)
+}
+
+
+const bfsExplored = []
+const queue = [V]
+while(queue.length !== 0){
+    let popped = queue.shift()
+    if(bfsExplored.includes(popped)) continue
+    bfsExplored.push(popped)
+    if(typeof graph[popped] !== 'object') continue
+
+    for(let i = 0; i < graph[popped].length; i++){
+        if(!bfsExplored.includes(graph[popped][i]))
+            queue.push(graph[popped][i])
+    }
+}
+
+console.log(bfsExplored.join(' '))


### PR DESCRIPTION
# 예외처리
- 98%에서 계속 typeError 가 뜨길래 결국 질문게시판에서 반례를 찾아봤다
- 반례는 DFS/BFS 시작 노드가 아무 노드와도 연결되지 않은 상황이었다.
```
5 4 1  // 노드 수, 간선 수, 시작 노드
2 3    // 연결된 간선 : 2와 3이 연결
3 4
4 5
5 2

// 아래는 나와야 하는 정답
1  // DFS 탐색 순서
1  // BFS 탐색 순서
```
즉, 아래 그림과 같은 상황
<img src="https://github.com/Jungle-7-Algorithm-study/Algorithm-Study/assets/103736987/ee96c6c1-fb57-4a53-a97b-1e8c35119ee7" width=40%/>

# DFS 재귀
```js
let visited = new Array(n + 1).fill(0);
let answer_dfs = [];
// DFS
function DFS(v) {
  if (visited[v]) return;
  visited[v] = 1;
  answer_dfs.push(v);
  for (let i = 0; i < graph[v].length; i++) {
    let next = graph[v][i];
    if (visited[next] === 0) {
      DFS(next);
    }
  }
}
DFS(v);
```
- BFS는 반복문으로

# 느낀점
visited는 배열 만들어서 includes 쓰는거보다 `let visited = new Array(n + 1).fill(0);` 처럼 만들어서 확인하는게 더 효율적이니 저 방법을 습관화시키자