### PR TITLE
[2024-03-05] 최승현 [BFS]

### DIFF
--- a/최승현/leet/queue/27737.py
+++ b/최승현/leet/queue/27737.py
@@ -1,0 +1,79 @@
+"""
+https://boj.kr/27737
+"""
+
+from sys import stdin
+from collections import deque
+from math import ceil
+
+input = stdin.readline
+DELTAS = [-1, 0, 1, 0]
+
+
+def deltas():
+    for i in range(4):
+        yield DELTAS[i], DELTAS[(i + 1) % 4]
+
+
+def sol(n, m, k, board) -> tuple[bool, int]:
+    """
+    bfs
+    """
+    if m == 0:
+        return False, 0
+
+    is_possible = False
+
+    for i in range(n):
+        for j in range(n):
+            if not board[i][j]:
+                continue
+            """do bfs traverse and count all cells that can be planted"""
+            q = deque()
+            cnt = 0
+
+            q.append((i, j))
+
+            while q:
+                y, x = q.popleft()
+
+                if not board[y][x]:
+                    continue
+                # visit
+                board[y][x] = False
+                cnt += 1
+
+                for di, dj in deltas():
+                    ci, cj = y + di, x + dj
+                    if not (0 <= ci < n and 0 <= cj < n):
+                        continue
+                    if board[ci][cj]:
+                        q.append((ci, cj))
+
+            """determine the number of spores needed"""
+            is_possible = True
+            spores_need = ceil(cnt / k)
+            m -= spores_need
+            if m < 0:
+                return False, 0
+
+        # end for
+    # end for
+
+    if is_possible:
+        return True, m
+    return False, 0
+
+
+if __name__ == "__main__":
+    n, m, k = [int(x) for x in input().strip().split()]
+
+    board = [[True if x == "0" else False for x in input().strip().split()] for _ in range(n)]
+
+    is_possible, remain_spore = sol(n, m, k, board)
+
+    if is_possible:
+        print("POSSIBLE")
+        print(remain_spore)
+    else:
+        print("IMPOSSIBLE")


### PR DESCRIPTION
지하철에서 부랴부랴 풀었읍니다.. BFS로 버섯이 퍼질 수 있는 칸의 수를 세는데, 버섯 하나당 k칸을 메울 수 있고 한 자리에 버섯을 몰아서 심으면 k * x개의 칸을 메울 수 있다는 점 때문에 ceil(버섯이 퍼질 수 있는 칸의 수 / k) 를 해 주어야 넉넉하게 버섯으로 도배할 수 있다.

BFS는 인접 노드를 방문할 때 방문 체크를 하는 걸로 알고 있는데, 이렇게만 하니까 같은 칸을 여러 번 방문하는 문제를 발견했다. 따라서 queue에서 하나를 popleft하고 방문체크를 하는 것으로 버그를 고쳤다.

75%에서 틀렸습니다가 나왔는데, 그 이유는 문제 조건에 따라 **버섯 포자를 하나라도 사용하고** 농사가 가능하기 때문이다. 따라서 아래 반례의 결과는 IMPOSSIBLE이다. 단 한개도 버섯을 심을 수 없는 경우.

```
2 2 1
1 1
1 1
```