### PR TITLE
[2024-03-07] 최승현 [순환큐]

### DIFF
--- a/최승현/leet/queue/649.py
+++ b/최승현/leet/queue/649.py
@@ -1,0 +1,103 @@
+"""
+https://leetcode.com/problems/dota2-senate/
+"""
+
+from collections import deque
+
+
+class Solution:
+    def predictPartyVictory(self, senate: str) -> str:
+        """
+        Radiant 팀과 Dire 팀이 있는데, 한 쪽만 남을 때까지 서로 죽인다. (?)
+        매 라운드 마다 i = 0부터 한 칸씩 이동하며 철퇴를 날릴 수 있기 때문에
+        가능한 살아있는 앞에 적군을 없애는 것이 이득이다. 죽은 senate들은 앞으로
+        모든 라운드에서 영향력을 행사할 수 없다.
+        """
+
+        alive_radiants = deque()
+        alive_dires = deque()
+
+        for i, c in enumerate(senate):
+            # initialize alive senates
+            match c:
+                case "R":
+                    alive_radiants.append(i)
+                case "D":
+                    alive_dires.append(i)
+
+        # senate의 생사확인 테이블
+        alive = [True for _ in range(len(senate))]
+
+        while alive_radiants and alive_dires:
+            # Each Rounds
+            for i, c in enumerate(senate):
+                if not alive[i]:
+                    continue
+
+                opponent = alive_radiants
+                if c == "R":
+                    opponent = alive_dires
+
+                slay = opponent.popleft()
+                alive[slay] = False
+
+                if not opponent:
+                    break
+
+        if alive_radiants:
+            return "Radiant"
+        return "Dire"
+
+
+class Solution2:
+    def predictPartyVictory(self, senate: str) -> str:
+        """
+        내 오른쪽에 있는 적을 먼저 처리하는 것이 이득이더라
+        deque을 현재 인덱스보다 큰 놈이 나올 때까지 꺼내서 다시 queue에 집어넣으면 되겠다.
+        """
+        alive_radiants = deque()
+        alive_dires = deque()
+        alive = [True for _ in range(len(senate))]
+
+        for i, c in enumerate(senate):
+            # initialize alive senates
+            if c == "R":
+                alive_radiants.append(i)
+            else:
+                alive_dires.append(i)
+
+        while alive_radiants and alive_dires:
+
+            for i, c in enumerate(senate):
+                if not alive[i]:
+                    continue
+                attackers = alive_radiants
+                dependers = alive_dires
+                if c == "D":
+                    attackers, dependers = dependers, attackers
+
+                if i != attackers[0]:
+                    continue
+
+                attacker = attackers.popleft()
+                depender = dependers.popleft()
+                alive[depender] = False
+
+                attackers.append(attacker)
+
+                if not dependers:
+                    break
+
+        if alive_radiants:
+            return "Radiant"
+        return "Dire"
+
+
+if __name__ == "__main__":
+    s = Solution2()
+
+    print(s.predictPartyVictory("RD"))
+    print(s.predictPartyVictory("RDD"))
+    print(s.predictPartyVictory("RDRD"))
+    print(s.predictPartyVictory("DDRRRDR"))
+    print(s.predictPartyVictory("DRRDRDRDRDDRDRDR"))


### PR DESCRIPTION
## 문제 설명

도타2 운영진이 두 팀으로 나뉘었다 각각 Dire와 Radiant이다. 모든 운영진은 자기 차례에 두 행동 중 하나를 취할 수 있다.

1. 상대팀 중 한 명을 처치한다. 처치당한 운영진은 자기 차례에 아무 행사도 할 수 없다.
2. 상대팀이 한 명도 없는 경우, 자신의 팀의 승리를 외친다.

"R", "D"로 이루어진 `senate` 라는 이름의 문자열이 주어질때, 모든 운영진들이 가장 합리적인 선택만을 수행한다고 가정할때 어느 팀이 승리하는지 알아내는 문제.

## 시뮬레이션

- Input: senate = "DDRRRDR"
- Output: "Radiant"
- Explanation:

Round 1:

[0] D -> [2] // 0번째 운영자가 2번째 운영자를 처치했다는 의미
[1] D -> [3]
[2] R -> banned
[3] R -> banned
[4] R -> [5]
[5] D -> banned
[6] R -> [0]

Round 2:

[0] D -> banned
[1] D -> [4]
[2] R -> banned
[3] R -> banned
[4] R -> banned
[5] D -> banned
[6] R -> [1]

Round 3:

[0] ~ [5] -> banned
[6] R -> declare victory on "Radiant"

## 구현

처음에는 큐를 사용하긴 하는데, 그저 처음 나타나는 상대팀을 처치하는 걸로 구현을 했더니 오답이 나왔다. 따라서 Solution2에서는 순환큐로 구현하여 자기가 상대 운영자를 처치한 경우 스스로 해당 큐의 맨 뒤로 들어가게된다.