### PR TITLE
[2024/03/20] 전성태

### DIFF
--- a/전성태/백준/DFS/2617.js
+++ b/전성태/백준/DFS/2617.js
@@ -1,0 +1,40 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const [N, M] = stdin[0].split(' ').map(Number)
+const maxCnt = (N + 1) / 2 // 보다 작거나 큰게 이 갯수가 되면서부터는 나가리
+const bigArr = Array(N+1)
+const smallArr = Array(N+1)
+let ans = 0;
+for(let i = 1; i <= N; i++){
+    bigArr[i] = []
+    smallArr[i] = []
+}
+
+
+for(let i = 1; i <= M; i++){
+    let [big, small] = stdin[i].split(' ').map(Number)
+    bigArr[small].push(big)
+    smallArr[big].push(small)
+}
+
+let visited
+for(let i = 1; i <= N; i++){
+    visited = Array(N+1).fill(false)
+    if (DFS(i, bigArr) >= maxCnt || DFS(i, smallArr) >= maxCnt) ans++;
+}
+
+function DFS(num, arr){
+    if(!arr[num].length) return 0
+
+    let countBig = 0
+    let child = arr[num]
+    for(let i = 0; i < child.length; i++){
+        if(!visited[child[i]]){
+            visited[child[i]] = true
+            countBig++
+            countBig += DFS(child[i], arr)
+        }
+    }
+    return countBig
+}
+
+console.log(ans)


### PR DESCRIPTION
# 구슬 찾기
> https://www.acmicpc.net/problem/2617

1. 각각 구슬에 대해 그 구슬보다 큰 배열 하나, 작은 배열 하나씩 생성하여 값을 넣는다.
```js
const bigArr = Array(N+1)
const smallArr = Array(N+1)
let ans = 0;
for(let i = 1; i <= N; i++){
    bigArr[i] = []
    smallArr[i] = []
}


for(let i = 1; i <= M; i++){
    let [big, small] = stdin[i].split(' ').map(Number)
    bigArr[small].push(big)
    smallArr[big].push(small)
}
```

2. 각 구슬에 대해 그 구슬보다 큰 배열과 작은 배열 각각 DFS를 돌면서 갯수를 확인한다. 
- 큰 배열과 작은 배열 둘 중 하나에서라도 maxCnt 와 같거나 클 경우 이 구슬은 중간이 될 수 없으므로 count 해준다.
- 이때 maxCnt는 `(구슬의 갯수 + 1) / 2` 이다.
```js
let visited
for(let i = 1; i <= N; i++){
    visited = Array(N+1).fill(false)
    if (DFS(i, bigArr) >= maxCnt || DFS(i, smallArr) >= maxCnt) ans++;
}

function DFS(num, arr){
    if(!arr[num].length) return 0

    let countBig = 0
    let child = arr[num]
    for(let i = 0; i < child.length; i++){
        if(!visited[child[i]]){
            visited[child[i]] = true
            countBig++
            countBig += DFS(child[i], arr)
        }
    }
    return countBig
}
```
- 이때 주의해야 할 점은 방문노드를 세줘야 한다는 것이다.
  - 사이클이 일어나지 않는 상황인데도 왜 방문노드를 세어줘야 하냐고 할 수도 있다. 아래와 같은 입력이 들어온다 가정해보자
    ```bash
    5 5
    2 1
    4 3
    5 1
    4 2
    5 4
    ```
  - 배열을 표로 그리면 아래와 같을 것이다.
    <img src="https://github.com/Jungle-7-Algorithm-study/Algorithm-Study/assets/103736987/f6aa1913-69ef-4213-9365-5e85ad55a3a0" width=30%/>
  - 이런 상황에서는 1번 구슬에 대해 DFS를 진행하여 `1 : 2 -> 4 -> 5` 를 거치고 리턴이 된 후, 1의 또다른 자식인 5를 방문하려 할 것이다. 이때 만약 방문처리에 대한 구현이 없다면 이미 5에 대한 갯수를 세었음에도 불구하고 또 갯수를 1 더하게 된다. 이를 막기 위해 방문 처리가 필요하다.
  - 단, 큰 배열과 작은 배열에 대해 각각 DFS를 돌릴 때 다른 visited 방문 배열을 쓸 필요는 없다. 왜냐하면 그 구슬보다 큰 배열을 돌면서 한 방문처리는 그 구슬보다 작은 배열을 돌 때에는 방문할 일이 없기 때문이다.

3. 갯수를 센 ans를 출력해주면 끝.
```js
console.log(ans)
```

### 문제를 그림으로 나타내자면 아래와 같다.
<img src="https://github.com/Jungle-7-Algorithm-study/Algorithm-Study/assets/103736987/7d34bdc6-c641-4416-9343-ea937112ee07" width= 70% />
