### PR TITLE
[2024/03/27] 전성태_BFS,DFS visited 위치 차이 이유

### DIFF
--- a/전성태/백준/BFS/1916.js
+++ b/전성태/백준/BFS/1916.js
@@ -1,0 +1,98 @@
+class MinHeap{
+    constructor(){
+        this.heap = []
+        this.length = 0
+    }
+
+    insert(item,cost){
+        this.heap.push([item,cost])
+        this.#increase()
+        this.length++
+    }
+
+    #increase(){
+        let curIdx = this.heap.length-1
+        while(curIdx > 0){
+            let parentIdx = ~~((curIdx-1)/2)
+            if(this.heap[curIdx][1] < this.heap[parentIdx][1])
+                [this.heap[curIdx], this.heap[parentIdx]] = [this.heap[parentIdx], this.heap[curIdx]]
+            else break
+
+            curIdx = parentIdx
+        }
+    }
+
+    extractMin(){
+        if(this.heap.length === 0) return -1
+        if(this.heap.length === 1) return this.heap.pop()
+        let ret = this.heap[0]
+        this.heap[0] = this.heap.pop()
+        this.#heapify()
+        return ret
+    }
+
+    #heapify(){
+        let curIdx = 0
+        while(curIdx < this.heap.length-1){
+            let leftChild = curIdx*2+1
+            let rightChild = curIdx*2+2
+            let minIdx = curIdx
+            if(leftChild < this.heap.length && this.heap[minIdx][1] > this.heap[leftChild][1])
+                minIdx = leftChild
+            if(rightChild < this.heap.length && this.heap[minIdx][1] > this.heap[rightChild][1])
+                minIdx = rightChild
+            if(minIdx == curIdx) break
+            else{
+                [this.heap[curIdx], this.heap[minIdx]] = [this.heap[minIdx], this.heap[curIdx]]
+                curIdx = minIdx
+            }
+        }
+    }
+
+    size(){
+        return this.heap.length
+    }
+}
+
+
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const N = Number(stdin[0])
+const M = Number(stdin[1])
+const graph = {}
+for(let i = 1; i <= N; i++){
+    graph[i] = []
+}
+for(let i = 2; i < M + 2;i++){
+    let [start, end, cost] = stdin[i].split(' ').map(Number)
+    graph[start].push([end, cost])
+}
+const [start, end] = stdin[M+2].split(' ').map(Number)
+
+const queue = new MinHeap()
+queue.insert(start,0)
+
+const costArr = Array(N+1).fill(Infinity)
+for(let i = 0; i < graph[start].length; i++){
+    let [city, cost] = graph[start][i]
+    costArr[city] = cost
+}
+
+const visited = Array(N+1).fill(0)
+ 
+while(queue.size()){
+    let [city, curcost] = queue.extractMin()
+    if(visited[city]) continue
+    visited[city] = 1
+
+    for(let i = 0; i < graph[city].length;i++){
+        let nextCity = graph[city][i][0]
+        let nextCost = graph[city][i][1]
+        if(!visited[nextCity]){ // 방문 체크 하는 이유 : 이미 방문했다는것은 지금 루트를 통해서 가는것보다 cost가 작다는것. 애초에 시작부터 루트까지가 이미 방문한 cost보다 높다는 것
+            queue.insert(nextCity,(curcost + nextCost))
+            if(costArr[nextCity] > (curcost + nextCost)) costArr[nextCity] = curcost + nextCost
+        }
+    }
+}
+
+console.log(costArr[end])
+

--- a/전성태/백준/BFS/2665.js
+++ b/전성태/백준/BFS/2665.js
@@ -1,0 +1,100 @@
+class MinHeap{
+    constructor(){
+        this.heap = []
+    }
+
+    insert(item){
+        this.heap.push(item)
+        this.#increaseHeap()
+    }
+
+    #increaseHeap(){
+        let curIdx = this.heap.length-1
+        while(curIdx > 0){
+            let parentIdx = ~~((curIdx - 1)/2)
+            if(this.heap[parentIdx][1] > this.heap[curIdx][1]){
+                [this.heap[curIdx], this.heap[parentIdx]] = [this.heap[parentIdx], this.heap[curIdx]]
+                curIdx = parentIdx
+            } else break
+        }
+    }
+
+    extractMin(){
+        if(!this.heap.length) return -1
+        else if (this.heap.length === 1) return this.heap.pop()
+        let ret = this.heap[0]
+        this.heap[0] = this.heap.pop()
+        this.#heapify()
+        return ret
+    }
+
+    #heapify(){
+        let curIdx = 0
+        while(curIdx < this.heap.length-1){
+            let leftChild = curIdx * 2 + 1
+            let rightChild = curIdx * 2 + 2
+            let minIdx = curIdx
+
+            if(leftChild < this.heap.length && this.heap[leftChild][1] < this.heap[minIdx][1]){
+                minIdx = leftChild
+            }
+
+            if(rightChild < this.heap.length && this.heap[rightChild][1] < this.heap[minIdx][1]){
+                minIdx = rightChild
+            }
+
+            if(minIdx === curIdx)break
+            else{
+                [this.heap[minIdx], this.heap[curIdx]] = [this.heap[curIdx], this.heap[minIdx]]
+                curIdx = minIdx
+            }
+        }
+    }
+
+    size(){
+        return this.heap.length
+    }
+}
+
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const N = Number(stdin[0])
+const graph = Array(N)
+const visited = Array(N)
+for(let i = 1; i <= N; i++){
+    graph[i-1] = stdin[i].split('').map(Number)
+    visited[i-1] = Array(N).fill(0)
+}
+
+const minHeap = new MinHeap()
+minHeap.insert([[0,0],0])
+
+// 위, 왼, 아, 오
+const dy = [-1, 0, 1, 0]
+const dx = [0, -1, 0, 1]
+
+const ans = []
+
+while(minHeap.size()){
+    let [[y,x], cost] = minHeap.extractMin()
+
+    if(y === N-1 && x === N-1){
+        ans.push(cost)
+        break
+    }
+
+    for(let i = 0; i < 4; i++){
+        let dirY = y + dy[i]
+        let dirX = x + dx[i]
+        if(0 <= dirY && dirY < N && 0 <= dirX && dirX < N && !visited[dirY][dirX]){
+            visited[dirY][dirX] = 1
+            if(graph[dirY][dirX]){
+                minHeap.insert([[dirY,dirX],cost])
+            } else {
+                minHeap.insert([[dirY,dirX],cost + 1])
+            }
+        }
+    }
+}
+console.log(ans.reduce((acc,prev)=>
+    acc > prev ? prev : acc
+).toString())

--- a/전성태/백준/DFS/2617.js
+++ b/전성태/백준/DFS/2617.js
@@ -1,0 +1,40 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const [N, M] = stdin[0].split(' ').map(Number)
+const maxCnt = (N + 1) / 2 // 보다 작거나 큰게 이 갯수가 되면서부터는 나가리
+const bigArr = Array(N+1)
+const smallArr = Array(N+1)
+let ans = 0;
+for(let i = 1; i <= N; i++){
+    bigArr[i] = []
+    smallArr[i] = []
+}
+
+
+for(let i = 1; i <= M; i++){
+    let [big, small] = stdin[i].split(' ').map(Number)
+    bigArr[small].push(big)
+    smallArr[big].push(small)
+}
+
+let visited
+for(let i = 1; i <= N; i++){
+    visited = Array(N+1).fill(false)
+    if (DFS(i, bigArr) >= maxCnt || DFS(i, smallArr) >= maxCnt) ans++;
+}
+
+function DFS(num, arr){
+    if(!arr[num].length) return 0
+
+    let countBig = 0
+    let child = arr[num]
+    for(let i = 0; i < child.length; i++){
+        if(!visited[child[i]]){
+            visited[child[i]] = true
+            countBig++
+            countBig += DFS(child[i], arr)
+        }
+    }
+    return countBig
+}
+
+console.log(ans)


### PR DESCRIPTION
# DFS와 BFS의 방문 처리 시점이 다른 이유
- DFS는 그 지점을 방문한 직후에 방문처리를 한다.
- BFS는 큐에 넣게 전에 방문처리를 하고 큐에 넣는다.

### DFS에서 방문 직후 방문처리를 하는 이유
DFS에서는 그 지점을 방문한 직후 방문처리를 하게 된다.
1부터 시작하여 방문 순서가 [위쪽 -> 왼쪽 -> 아래쪽 -> 오른쪽] 이라고 할때 방문 직후 방문 처리를 하면 아래와 같이 의도한 대로 DFS가 된다. (재귀 대신 반복문 사용시)

<img src="https://github.com/Jungle-7-Algorithm-study/Algorithm-Study/assets/103736987/981cdda3-6ca8-4754-99a3-ffab65befc69" width=30%/>

그러나 DFS에서 만약 방문 처리를 for문으로 사방을 확인할 때 하게 되면 아래 그림처럼 의도한 방향대로 DFS가 흘러가지 않게 된다.

<img src="https://github.com/Jungle-7-Algorithm-study/Algorithm-Study/assets/103736987/eedb5af3-f33d-42c5-80ce-44127bd9d26f" width=30%/>

**즉, 모든 점을 다 돌기는 하겠지만 실제 방문순서와 방문가능지역 탐색순서가 다르게 된다.**

### BFS에서 큐에 넣기 전에 방문처리를 하는 이유
BFS에서 만약 DFS처럼 방문 직후 방문처리를 하면 어떻게 될까? 답은 '상관 없다'이다.
즉, 실제 방문순서와 방문가능지역 탐색순서가 다르지 않다.

하지만 방문처리를 방문한 이후에 하므로, 큐에 동일한 노드가 들어올수 있게 된다. 
아래는 [위쪽 -> 왼쪽 -> 아래쪽 -> 오른쪽] 순서로 1번부터 BFS를 할때 동일한 값이 큐로 들어오는 모습이다.

<img src="https://github.com/Jungle-7-Algorithm-study/Algorithm-Study/assets/103736987/24e82a66-a889-490b-b02c-1d6ff05c0a0e" width=50%/>

물론 큐에서 shift 되어 그 차례에 방문 확인을 하여 continue를 한다면 결과는 같겠지만, 같은 노드를 큐에 넣고 빼고 확인하는 낭비가 발생된다.
또한 만약 방문한 순서대로 좌표와 번호를 별도로 저장한다고 했을 때, 중복되어 값에 대해서는 마지막 값이 이전값을 덮어 쓰게는 문제가 발생하여 원하는 결과가 안 나오는 문제가 발생한다.