### PR TITLE
[2024/03/28] 전성태_3차원배열탐색_큐 구현 없는 shift 대체법

### DIFF
--- a/전성태/백준/BFS/2665.js
+++ b/전성태/백준/BFS/2665.js
@@ -1,0 +1,100 @@
+class MinHeap{
+    constructor(){
+        this.heap = []
+    }
+
+    insert(item){
+        this.heap.push(item)
+        this.#increaseHeap()
+    }
+
+    #increaseHeap(){
+        let curIdx = this.heap.length-1
+        while(curIdx > 0){
+            let parentIdx = ~~((curIdx - 1)/2)
+            if(this.heap[parentIdx][1] > this.heap[curIdx][1]){
+                [this.heap[curIdx], this.heap[parentIdx]] = [this.heap[parentIdx], this.heap[curIdx]]
+                curIdx = parentIdx
+            } else break
+        }
+    }
+
+    extractMin(){
+        if(!this.heap.length) return -1
+        else if (this.heap.length === 1) return this.heap.pop()
+        let ret = this.heap[0]
+        this.heap[0] = this.heap.pop()
+        this.#heapify()
+        return ret
+    }
+
+    #heapify(){
+        let curIdx = 0
+        while(curIdx < this.heap.length-1){
+            let leftChild = curIdx * 2 + 1
+            let rightChild = curIdx * 2 + 2
+            let minIdx = curIdx
+
+            if(leftChild < this.heap.length && this.heap[leftChild][1] < this.heap[minIdx][1]){
+                minIdx = leftChild
+            }
+
+            if(rightChild < this.heap.length && this.heap[rightChild][1] < this.heap[minIdx][1]){
+                minIdx = rightChild
+            }
+
+            if(minIdx === curIdx)break
+            else{
+                [this.heap[minIdx], this.heap[curIdx]] = [this.heap[curIdx], this.heap[minIdx]]
+                curIdx = minIdx
+            }
+        }
+    }
+
+    size(){
+        return this.heap.length
+    }
+}
+
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const N = Number(stdin[0])
+const graph = Array(N)
+const visited = Array(N)
+for(let i = 1; i <= N; i++){
+    graph[i-1] = stdin[i].split('').map(Number)
+    visited[i-1] = Array(N).fill(0)
+}
+
+const minHeap = new MinHeap()
+minHeap.insert([[0,0],0])
+
+// 위, 왼, 아, 오
+const dy = [-1, 0, 1, 0]
+const dx = [0, -1, 0, 1]
+
+const ans = []
+
+while(minHeap.size()){
+    let [[y,x], cost] = minHeap.extractMin()
+
+    if(y === N-1 && x === N-1){
+        ans.push(cost)
+        break
+    }
+
+    for(let i = 0; i < 4; i++){
+        let dirY = y + dy[i]
+        let dirX = x + dx[i]
+        if(0 <= dirY && dirY < N && 0 <= dirX && dirX < N && !visited[dirY][dirX]){
+            visited[dirY][dirX] = 1
+            if(graph[dirY][dirX]){
+                minHeap.insert([[dirY,dirX],cost])
+            } else {
+                minHeap.insert([[dirY,dirX],cost + 1])
+            }
+        }
+    }
+}
+console.log(ans.reduce((acc,prev)=>
+    acc > prev ? prev : acc
+).toString())

--- a/전성태/백준/BFS/7569.js
+++ b/전성태/백준/BFS/7569.js
@@ -1,0 +1,67 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const [M, N, H] = stdin[0].split(' ').map(Number)
+let row = 1
+const graph = Array(H)
+const visited = Array(H)
+const queue = []
+for(let i = 1; i <= H; i++){
+    graph[i-1] = Array(N)
+    visited[i-1] = Array(N)
+    for(let j = 0; j < N; j++){
+        graph[i-1][j] = stdin[row].split(' ').map((tom,idx)=>{
+            let parsedTomato = Number(tom)
+            if(parsedTomato === 1) queue.push([i-1,j,idx])
+            return Number(parsedTomato)
+        })
+        visited[i-1][j] = Array(M).fill(0)
+        row++
+    }
+}
+
+function DFS(){
+    //위, 왼, 아, 오, 앞, 뒤
+    const dz = [0, 0, 0, 0, 1, -1]
+    const dy = [-1, 0, 1, 0, 0, 0]
+    const dx = [0, -1, 0, 1, 0, 0]
+    for(let i = 0; i < queue.length; i++){
+        let [z,y,x] = queue[i]
+        visited[z][y][x] = 1
+    }
+
+    let i = 0
+    while(queue.length > i){
+        let [z,y,x] = queue[i]
+        i++
+        for(let i = 0; i < 6; i++){
+            let dirZ = z + dz[i]
+            let dirY = y + dy[i]
+            let dirX = x + dx[i]
+            if(0 <= dirZ && dirZ < H && 0 <= dirY && dirY < N && 0 <= dirX && dirX < M){
+                if(graph[dirZ][dirY][dirX] === 0 && !visited[dirZ][dirY][dirX]){
+                    visited[dirZ][dirY][dirX] = 1
+                    graph[dirZ][dirY][dirX] = graph[z][y][x] + 1
+                    queue.push([dirZ,dirY,dirX])
+                }
+            }
+        }
+    }
+}
+
+DFS()
+
+const ans = []
+
+function check(){
+    for(let z = 0; z < H; z++){
+        for(let y = 0; y < N; y++){
+            for(let x = 0; x < M; x++){
+                if(graph[z][y][x] === 0) return -1
+                else ans.push(graph[z][y][x])
+            }
+        }
+    }
+}
+
+if(check() !== -1){
+    console.log(ans.reduce((a,b)=>a > b ? a : b)-1)
+} else console.log(-1)


### PR DESCRIPTION
# 3차원 배열 탐색
2차원에서 그냥 앞뒤만 추가하면 된다.
```js
//위, 왼, 아, 오, 앞, 뒤
const dz = [0, 0, 0, 0, 1, -1]
const dy = [-1, 0, 1, 0, 0, 0]
const dx = [0, -1, 0, 1, 0, 0]
```
나머지는 동일하게 하면 됨

# 클래스로 큐 구현 없이 index를 이용한 shift() 대체법
예를 들어 BFS를 한다고 할 때 `let i = 0` 을 while문 전에 미리 선언한다음, `while(queue.length > i)` 그리고 while 안에서 `i++`
```js
let i = 0
while(queue.length > i){
    let [z,y,x] = queue[i]
    i++
    //...
}