### PR TITLE
[2024/04/17] 전성태_이분탐색 lower bound

### DIFF
--- a/전성태/백준/기초 (문자열)/1157.js
+++ b/전성태/백준/기초 (문자열)/1157.js
@@ -1,0 +1,29 @@
+const strings = require('fs').readFileSync('/dev/stdin').toString().trim().toLowerCase()
+const alphabet = Array(123).fill(0)
+for(let i = 0; i < strings.length; i++){
+    alphabet[strings[i].charCodeAt()]++
+}
+let candCount = []
+let candIdx = []
+for(let i = 0; i < alphabet.length; i++){
+    if(alphabet[i]){
+        candCount.push(alphabet[i])
+        candIdx.push(i)
+    }
+}
+
+let maxCount = Math.max(...candCount)
+
+let maxIdx = 0
+let count = 0
+for(let i = 0; i < candCount.length; i++){
+    if(candCount[i] === maxCount){
+        count++
+        maxIdx = candIdx[i]
+    } 
+}
+
+if(count > 1) console.log('?')
+else {
+    console.log(String.fromCharCode(maxIdx).toUpperCase())
+}

--- a/전성태/백준/이분 탐색/3020.js
+++ b/전성태/백준/이분 탐색/3020.js
@@ -1,0 +1,49 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const [N, H] = stdin[0].split(' ').map(Number)
+const seok = []
+const jong = []
+for(let i = 1; i <= N/2; i++){
+    seok.push(parseInt(stdin[i * 2 - 1]))
+    jong.push(parseInt(stdin[i * 2]))
+}
+seok.sort((a,b)=>a-b)
+jong.sort((a,b)=>a-b)
+
+const levelSums = Array(H+1).fill(Infinity)
+
+for(let i = 1; i <= H; i++){
+    let seokSum = 0
+    let jongSum = 0
+    if(seok[seok.length-1] >= i){
+        seokSum = lowerBound(seok, 0, seok.length - 1, i)
+    }
+    if(jong[jong.length-1] >= (H-i+1)){
+        jongSum = lowerBound(jong, 0, jong.length - 1, H - i + 1)
+    }
+    let levelSum = seokSum + jongSum
+    levelSums[i] = levelSum
+}
+
+
+let maxBreak = Math.min(...levelSums)
+let count = 0
+for(let i = 0; i < levelSums.length; i++){
+    if(levelSums[i] === maxBreak) count++
+}
+console.log([maxBreak,count].join(' '))
+
+
+
+function lowerBound(arr, start, end, target){
+    if(start >= end){
+        return arr.length - end
+    }
+
+    let middle = ~~((start + (end))/2)
+
+    if(arr[middle] < target){
+        return lowerBound(arr, middle + 1, end, target)
+    } else {
+        return lowerBound(arr, start, middle, target)
+    }
+}


### PR DESCRIPTION
# Lower bound / Upper bound

`Lower bound` 와 `Upper bound` 는 경겟값을 찾는 `이분탐색`을 이용한 알고리즘이다.

때문에 정렬이 먼저 되있어야 하며, 시간 복잡도는 O(log n) 이다.

### Lower bound

> **특정 값의 시작 위치를 찾는 알고리즘**

예를 들어 아래와 같은 배열에서 찾고자 하는 값 3의 시작 위치를 찾을 때

<img src="https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https://blog.kakaocdn.net/dn/cDcl4d/btrUxdRXj9f/rEPGYLIYk7pK2bUXOKqWtK/img.png" width=70%/>

이분탐색과 똑같이 하되, 

- middle이 찾고자 하는 값보다 작으면 : start = mid + 1
- middle이 찾고자 하는 값보다 **크거나 같다면** : end = mid
- start ≥ end : end가 lower bound가 된다.

```jsx
function lower_bound(start, end, target){
    if(start >= end){
        return end // lower bound
    }

    let middle = ~~((start + end)/2)

    if(arr[middle] < target){
        lower_bound(middle + 1, end, target)
    } else {
        lower_bound(start, middle, target)
    }
}
```

### Upper bound

> 특정 값보다 처음으로 큰 값의 위치를 찾는 알고리즘
> 

예를 들어 아래와 같은 배열에서 찾고자 하는 값 3보다 처음으로 큰 값을 찾을 때

<img src="https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https://blog.kakaocdn.net/dn/bL9VBl/btrUus3uxhi/dAjAjIKvm1VpAt4CPgfRtK/img.png" width=70%/>

이분탐색과 똑같이 하되, 

- middle이 찾고자 하는 값보다 **작거나 같다면** : start = mid + 1
- middle이 찾고자 하는 값보다 크다면 : end = mid
- start ≥ end : end가 upper bound가 된다.

```jsx
function upper_bound(start, end, target){
    if(start >= end){
        return end // upper bound
    }

    let middle = ~~((start + end)/2)

    if(arr[middle] <= target){
        upper_bound(middle + 1, end, target)
    } else {
        upper_bound(start, middle, target)
    }
}
```

### 결론

코드상 upper bound 와 lower bound 의 차이는 **부등호**를 넣냐 마냐의 차이다.

참고로 찾고자 하는 값이 없을 때 lower bound와 upper bound는 찾고자 하는 값보다 큰 가장 첫번째 수가 된다.

ex) [1,3,5,7,8] 에서 6을 lower/upper bound 로 돌렸을 때 7이 lower/upper bound가 됨.


# 개똥벌레

> https://www.acmicpc.net/problem/3020

이 문제는 이분탐색의 lower bound를 이용해서 푸는 문제이다.
이분탐색은 정렬된 석순과 종유석 배열에 특정 높이에 대해 적용하며, lower bound로 개똥벌레가 갉가먹기 시작하는 인덱스를 이용하여 갯수를 센다.

### 1. 동굴의 길이는 짝수이며 석순이 항상 먼저 나오므로, 석순과 종유석을 나누어 배열에 저장한다.
- 배열에 저장 후, 이분탐색을 위해 sort 한다.
```jsx
const [N, H] = stdin[0].split(' ').map(Number)
const seok = []
const jong = []
for(let i = 1; i <= N/2; i++){
    seok.push(parseInt(stdin[i * 2 - 1]))
    jong.push(parseInt(stdin[i * 2]))
}
seok.sort((a,b)=>a-b)
jong.sort((a,b)=>a-b)
```

### 2. 높이만큼 반복문을 돌며, 각각 높이에 대해 석순과 종유석의 lower bound를 구한다.
- 각 배열에 대해 lowerbound를 구하는 것이므로, 석순/종유석의 최대 높이(sort 했으므로 맨 마지막 요소)보다 높은 상황까지 lower bound 함수를 돌리면 0이 아닌 1개를 반환하므로, if문을 통해 제외시켜준다.
- 종유석은 하늘에 매달려 있다. 때문에 종유석이 땅에 붙어있다는 가정 하에, 높이 `i` 가 아닌 `H  - i + 1`을 lower bound의 타켓으로 넘겨준다.
- 이렇게 구한 두 갯수의 합을 배열 `levelSums` 에 저장한다.

```jsx
const levelSums = Array(H+1).fill(Infinity)

for(let i = 1; i <= H; i++){
    let seokSum = 0
    let jongSum = 0
    if(seok[seok.length-1] >= i){
        seokSum = lowerBound(seok, 0, seok.length - 1, i)
    }
    if(jong[jong.length-1] >= (H-i+1)){
        jongSum = lowerBound(jong, 0, jong.length - 1, H - i + 1)
    }
    let levelSum = seokSum + jongSum
    levelSums[i] = levelSum
}
```

### 3. `2`에서 저장한 `levelSums` 배열의 최솟값이 개똥벌레가 파괴해야하는 장애물의 최솟값이다.
또한 반복문을 돌며 그 최솟값을 값으로 갖고 있는 요소의 갯수를 구하면, 그게 최소값을 갖는 구간의 갯수이다.
```jsx
let maxBreak = Math.min(...levelSums)
let count = 0
for(let i = 0; i < levelSums.length; i++){
    if(levelSums[i] === maxBreak) count++
}
console.log([maxBreak,count].join(' '))
```

### 4. 아래는 lower bound 함수이다.
```jsx
function lowerBound(arr, start, end, target){
    if(start >= end){
        return arr.length - end
    }

    let middle = ~~((start + (end))/2)

    if(arr[middle] < target){
        return lowerBound(arr, middle + 1, end, target)
    } else {
        return lowerBound(arr, start, middle, target)
    }
}
```