### PR TITLE
[2024/04/21] 전성태

### DIFF
--- a/전성태/백준/구현/1966.js
+++ b/전성태/백준/구현/1966.js
@@ -1,0 +1,35 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const T = parseInt(stdin[0])
+const ans = []
+for(let i = 1; i <= T; i++){
+    let [N, M] = stdin[i * 2 - 1].split(' ').map(Number)
+    let numCount = []
+    let queue = []
+    stdin[i * 2].split(' ').map((numStr,idx)=>{
+        let priority = parseInt(numStr)
+        numCount.push(priority)
+        queue.push([priority, idx])
+    })
+
+    numCount.sort((a,b)=>a-b)
+
+    let count = 0
+    let printCount = 0
+    while(count < queue.length){
+        let [priority, idx] = queue[count]
+        if(priority === numCount[numCount.length-1]){
+            printCount++
+            if(idx === M){
+                ans.push(printCount)
+                break
+            }
+            numCount.pop()
+        } else {
+            queue.push([priority, idx])
+        }
+
+        count++
+    }
+}
+
+console.log(ans.join('\n'))

--- a/전성태/백준/구현/5430.js
+++ b/전성태/백준/구현/5430.js
@@ -1,0 +1,106 @@
+class Node{
+    constructor(item){
+        this.item = item
+        this.next = null
+        this.prev = null
+    }
+}
+
+class LinkedList{
+    constructor(){
+        this.head = null;
+        this.tail = null;
+        this.length = 0;
+    }
+
+    push(item){
+        const node = new Node(item)
+        if(!this.head){
+            this.head = node
+        } else {
+            this.tail.next = node
+            node.prev = this.tail
+        }
+        this.tail = node
+        this.length++
+    }
+
+    popFront(){
+        if(!this.head) return -1
+        let ret = this.head.item
+        if(this.length === 1){
+            this.head = null
+            this.tail = null
+            this.length--
+            return ret
+        }
+        this.head.next.prev = null
+        this.head = this.head.next
+        this.length--
+        return ret
+    }
+
+    popBack(){
+        if(!this.tail) return -1
+        let ret = this.tail.item
+        if(this.length === 1){
+            this.head = null
+            this.tail = null
+            this.length--
+            return ret
+        }
+        this.tail.prev.next = null
+        this.tail = this.tail.prev
+        this.length--
+        return ret
+    }
+
+    size(){
+        return this.length
+    }
+}
+
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const T = parseInt(stdin[0])
+const ans = []
+for(let i = 1; i <= T; i++){
+    let command = stdin[i * 3 - 2].split('')
+    let arrNum = parseInt(stdin[i * 3 - 1])
+    let arr = stdin[i * 3].replace('[','').replace(']','').split(',')
+    if(arr.length === 1 && arr[0] === ''){
+        arr = []
+    }
+
+    const queue = new LinkedList()
+    for(let i = 0; i < arr.length; i++){
+        queue.push(arr[i])
+    }
+
+    let isError = false
+    let isReversed = false
+    for(let c = 0; c < command.length; c++){
+        if(command[c] === 'R'){
+            isReversed = !isReversed
+        } else {
+            if(queue.size() === 0){
+                ans.push('error')
+                isError = true
+                break
+            } else {
+                if(isReversed) queue.popBack()
+                else queue.popFront()
+            }
+        }
+    }
+
+    let ansArr = []
+    while(queue.size()){
+        if(isReversed) ansArr.push(queue.popBack())
+        else ansArr.push(queue.popFront())
+    }
+    
+    if(ansArr.length) ans.push(`[${ansArr.join(',')}]`)
+    else if(!isError) ans.push('[]')
+}
+
+console.log(ans.join('\n'))

--- a/전성태/백준/구현/5430_ans.js
+++ b/전성태/백준/구현/5430_ans.js
@@ -1,0 +1,36 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const T = parseInt(stdin[0])
+const ans = []
+for(let i = 1; i <= T; i++){
+    let command = stdin[i * 3 - 2].split('')
+    let arrNum = parseInt(stdin[i * 3 - 1])
+    let arr = JSON.parse(stdin[i * 3])
+
+    let isError = false
+    let isReversed = false
+    let startIdx = 0
+    let endIdx = arrNum - 1
+
+    for(let c = 0; c < command.length; c++){
+        if(command[c] === 'R'){
+            isReversed = !isReversed
+        } else {
+            if(startIdx > endIdx){
+                isError = true
+                break
+            } else {
+                if(isReversed) endIdx--
+                else startIdx++
+            }
+        }
+    }
+
+    const ansArr = arr.slice(startIdx, endIdx + 1)
+
+    if(isError) ans.push('error')
+    else{
+        ans.push(JSON.stringify(isReversed ? ansArr.reverse() : ansArr))
+    }
+}
+
+console.log(ans.join('\n'))


### PR DESCRIPTION
# 프린터 큐

> https://www.acmicpc.net/problem/1966

이 문제는 큐의 응용 문제이다.
큐에 문서의 중요도와 인덱스 요소로 갖는 배열을 넣고, 각 문서마다 중요도만 따로 다른 배열에 넣은 후 중요도 배열을 정렬한다.
이후 큐에서 하나씩 Pop 할 때 마다 중요도 배열과도 비교하여 중요도가 높은 문서는 프린트 하고 아닌 문서는 다시 큐로 push 하게 구현하였다.

### 1. 큐에 문서 삽입 및 중요도 배열 생성 후 정렬
```jsx
const T = parseInt(stdin[0])
const ans = []
for(let i = 1; i <= T; i++){
    let [N, M] = stdin[i * 2 - 1].split(' ').map(Number)
    let numCount = []
    let queue = []
    stdin[i * 2].split(' ').map((numStr,idx)=>{
        let priority = parseInt(numStr)
        numCount.push(priority)
        queue.push([priority, idx])
    })

    numCount.sort((a,b)=>a-b)
```

### 2. 큐에서 하나씩 pop하고 중요도 배열을 통해 중요도 체크 후, 제일 높은 중요도면 프린트하고 아니면 다시 큐에 삽입한다.
```jsx
    let count = 0
    let printCount = 0
    while(count < queue.length){
        let [priority, idx] = queue[count]
        if(priority === numCount[numCount.length-1]){
            printCount++
            if(idx === M){
                ans.push(printCount)
                break
            }
            numCount.pop()
        } else {
            queue.push([priority, idx])
        }

        count++
    }
}

console.log(ans.join('\n'))
```