### PR TITLE
[2024/02/22] 전성태_slice메모리초과

### DIFF
--- a/전성태/백준/구현/17413.js
+++ b/전성태/백준/구현/17413.js
@@ -1,0 +1,37 @@
+const str = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')[0]
+let arrStr = [...str]
+let toChange = new Map()
+let changeIdx = 0
+let ignore = false
+arrStr.map((e,idx)=>{
+    if(e === '<') ignore = true
+    else if(e === '>') {
+        changeIdx = idx + 1
+        ignore = false
+    }
+    else{
+        if(!ignore){
+            if(e === ' ') changeIdx = idx + 1
+            else{
+                if(!toChange.has(changeIdx)){
+                    toChange.set(changeIdx,e)
+                }
+                else {
+                    toChange.set(changeIdx, [e,toChange.get(changeIdx)].join(''))
+                }
+            }
+        }
+    }
+})
+
+toChange.forEach((e,idx)=>{
+    if(e){
+        for(let i = idx; i < idx + e.length; i++ ){
+            arrStr[i] = e[i - idx]
+        }
+        // arrStr = arrStr.slice(0,idx).join('') + e + arrStr.slice(idx + e.length).join('')
+        // 위 방법의 slice는 배열로부터 특정 범위를 **복사**하여 새로운 배열을 만들기 때문에 메모리 초과가 난다.
+    }
+})
+
+console.log(arrStr.join(''))

--- a/전성태/백준/구현/1966.js
+++ b/전성태/백준/구현/1966.js
@@ -1,0 +1,35 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const T = parseInt(stdin[0])
+const ans = []
+for(let i = 1; i <= T; i++){
+    let [N, M] = stdin[i * 2 - 1].split(' ').map(Number)
+    let numCount = []
+    let queue = []
+    stdin[i * 2].split(' ').map((numStr,idx)=>{
+        let priority = parseInt(numStr)
+        numCount.push(priority)
+        queue.push([priority, idx])
+    })
+
+    numCount.sort((a,b)=>a-b)
+
+    let count = 0
+    let printCount = 0
+    while(count < queue.length){
+        let [priority, idx] = queue[count]
+        if(priority === numCount[numCount.length-1]){
+            printCount++
+            if(idx === M){
+                ans.push(printCount)
+                break
+            }
+            numCount.pop()
+        } else {
+            queue.push([priority, idx])
+        }
+
+        count++
+    }
+}
+
+console.log(ans.join('\n'))


### PR DESCRIPTION
# 단어 뒤집기 2

> https://www.acmicpc.net/problem/17413

이 문제는 태그를 제외한 단어를 뒤집는 단순 문자열 구현 문제이다.

### 1. 문자열을 배열로 바꾼 후, `map`으로 반복문을 돌면서 
- `<` 가 나오면 `ignore`플래그를 true로, 
- `>` 가 나오면 `ignore`플래그를 false로 바꾼 후
  - `>`가 나온 이후 다시 `<`가 나오지 않는 한, 단어가 나오므로, 이후부터 저장할 index를 위해 현재 Index + 1을 `changeIdx`에 저장해둔다.
- `<` 나 `>` 가 아니면서 `ignore`플래그도 false 일 때 단어를 map 자료구조에 저장한다.
  - map의 key는 `changeIdx` 즉, 현재 문자열의 인덱스이며
  - value에는 `[새로운 단어, 이전 단어들].join()` 를 통해 단어를 뒤집으며 저장한다.
- 이렇게 되면 map 자료구조에는 뒤집은 단어들이 들어갈 index가 key로, 뒤집은 단어들이 value로 들어간다.
```jsx
const str = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')[0]
let arrStr = [...str]
let toChange = new Map()
let changeIdx = 0
let ignore = false
arrStr.map((e,idx)=>{
    if(e === '<') ignore = true
    else if(e === '>') {
        changeIdx = idx + 1
        ignore = false
    }
    else{
        if(!ignore){
            if(e === ' ') changeIdx = idx + 1
            else{
                if(!toChange.has(changeIdx)){
                    toChange.set(changeIdx,e)
                }
                else {
                    toChange.set(changeIdx, [e,toChange.get(changeIdx)].join(''))
                }
            }
        }
    }
})
```

### 2. 이제 이 map을 forEach로 반복문을 돌면서, 각각 뒤집은 단어들을 원래의 문자열에 대체한다.
```jsx
toChange.forEach((e,idx)=>{
    if(e){
        for(let i = idx; i < idx + e.length; i++ ){
            arrStr[i] = e[i - idx]
        }
    }
})

console.log(arrStr.join(''))
```

-  주의할 점
처음에는 아래와 같이 slice를 통해서 새로운 문자열을 계속 생성했다.
```jsx
toChange.forEach((e,idx)=>{
    if(e){
        arrStr = arrStr.slice(0,idx).join('') + e + arrStr.slice(idx + e.length).join('')
    }
})

console.log(arrStr.join(''))
```
그러나 이 방법은 slice를 사용하며, slice는 배열로부터 특정 범위를 **복사**하여 새로운 배열을 만들기 때문에 메모리 초과가 난다.
때문에 반복문을 돌며 원래 문자열에 바로 대입하는게 더 메모리 효율적이다.