### PR TITLE
[2024/04/25] 전성태_DFS+BFS

### DIFF
--- a/전성태/백준/구현/14502.js
+++ b/전성태/백준/구현/14502.js
@@ -1,0 +1,83 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const [N, M] = stdin[0].split(' ').map(Number)
+const graph = Array(N)
+const virus = []
+const empty = []
+const answers = []
+for(let i = 1; i <= N; i++){
+    graph[i-1] = stdin[i].split(' ').map((e,idx)=>{
+        let num = parseInt(e)
+        if(num === 2){
+            virus.push([i-1,idx])
+        } else if(num === 0){
+            empty.push([i-1,idx])
+        }
+        return num
+    })
+}
+
+DFS()
+
+function DFS(arr = [], visited = Array(empty.length).fill(0)){
+    if(arr.length === 3){
+        let fixedGraph = graph.map(e=>[...e])
+        for(let i = 0; i < 3; i++){
+            let [y, x] = arr[i]
+            fixedGraph[y][x] = 1
+        }
+        checkNonVirus(fixedGraph)
+        return
+    }
+
+    for(let i = 0; i < empty.length; i++){
+        if(!visited[i]){
+            arr.push(empty[i])
+            visited[i] = 1
+            DFS(arr, [...visited])
+            arr.pop()
+        }
+    }
+
+}
+
+function checkNonVirus(fixedGraph){
+    let count = 0
+    const visited = Array.from(Array(N),()=> new Array(M).fill(0))
+    for(let i = 0; i < virus.length; i++){
+        let [y, x] = virus[i]
+        if(!visited[y][x]){
+            count += BFS(y, x, fixedGraph, visited)
+        }
+    }
+    answers.push(count)
+}
+
+
+function BFS(y,x, fixedGraph, visited){
+    // 위 왼 아 오
+    const dy = [-1, 0, 1, 0]
+    const dx = [0, -1, 0, 1]
+    visited[y][x] = 1
+    const queue = [[y,x]]
+    let popIdx = 0;
+    let count = 0;
+    while(popIdx < queue.length){
+        let [y,x] = queue[popIdx]
+
+        for(let i = 0; i < 4; i++){
+            dirY = y + dy[i]
+            dirX = x + dx[i]
+            if(0 <= dirY && dirY < N && 0 <= dirX && dirX < M){
+                if(fixedGraph[dirY][dirX] === 0 && !visited[dirY][dirX]){
+                    visited[dirY][dirX] = 1
+                    count++
+                    queue.push([dirY,dirX])
+                }
+            }
+        }
+        popIdx++
+    }
+    return count
+}
+
+console.log(empty.length - answers.reduce((a,b)=>a>b?b:a) - 3)

--- a/전성태/백준/구현/15686.js
+++ b/전성태/백준/구현/15686.js
@@ -1,0 +1,48 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const [N, M] = stdin[0].split(' ').map(Number)
+const chicken = []
+const houses = []
+const graph = Array.from(Array(N), () => new Array(N))
+for(let i = 1; i <= N; i++){
+    graph[i-1] = stdin[i].split(' ').map((e,idx)=>{
+        let num = parseInt(e)
+        if(num === 1) houses.push([i - 1, idx])
+        if(num === 2) chicken.push([i - 1, idx])
+    })
+}
+
+const visited = Array(chicken.length).fill(0)
+const cityDists = []
+
+DFS([],0,visited)
+
+function DFS(arr, count, visited){
+    if(count === M){
+        cityDists.push(getCityChickenDist(arr))
+        return
+    }
+
+    for(let i = 0; i < chicken.length; i++){
+        if(!visited[i]){
+            arr.push(chicken[i])
+            visited[i] = 1
+            DFS(arr, count + 1, [...visited])
+            arr.pop()
+        }
+    }
+}
+
+function getCityChickenDist(chickenArr){
+    let distArr = []
+    houses.forEach(home => {
+        let min = Infinity
+        chickenArr.forEach((chick)=>{
+            let dist = Math.abs(home[0]-chick[0]) + Math.abs(home[1]-chick[1])
+            if(dist < min) min = dist
+        })
+        distArr.push(min)
+    });
+    return distArr.reduce((a,b)=>a+b,0)
+}
+
+console.log(cityDists.reduce((a,b)=>a>b?b:a))

--- a/전성태/백준/기초 (문자열)/27866.js
+++ b/전성태/백준/기초 (문자열)/27866.js
@@ -1,0 +1,5 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const str = stdin[0]
+const num = stdin[1]
+
+console.log(str[num-1])


### PR DESCRIPTION
# 연구소

> https://www.acmicpc.net/problem/14502

이 문제는 DFS를 사용하여 3개의 벽을 세우는 모든 경우의 수를 구하고, 그 경우의 수에 따라 바이러스가 퍼질 수 있는 갯수를 BFS로 구하여 답을 내었다.

### 1. 우선 그래프를 입력 받는다. 입력 받는 과정에 바이러스가 있는 좌표와 빈 공간의 좌표를 별도의 배열에 저장하였다.
```jsx
const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
const [N, M] = stdin[0].split(' ').map(Number)
const graph = Array(N)
const virus = []
const empty = []
const answers = [] // 나중에 정답을 담을 배열 미리 선언
for(let i = 1; i <= N; i++){
    graph[i-1] = stdin[i].split(' ').map((e,idx)=>{
        let num = parseInt(e)
        if(num === 2){
            virus.push([i-1,idx]) // 바이러스 좌표 저장
        } else if(num === 0){
            empty.push([i-1,idx]) // 빈 공간 좌표 저장
        }
        return num
    })
}
``` 

### 2. DFS를 돌면서 벽을 설치할 좌표 3개의 모든 경우의 수를 구한다.
- 순서 없고 중복 없는 조합이기 때문에 DFS를 호출하여 하위 깊이로 내려갈 때 `visited` 배열을 복사하여 보냈다.
  - 이렇게 하여 하위 깊이에서 방문 처리 된 `visited` 배열은 상위 레벨로 다시 return 할 때 없어진다.
  - 이렇게 안 하면 하위 레벨에서 방문한 노드들을 상위 레벨로 return 됐을 때 방문하지 않게 되므로 모든 경우의 수를 구할 수 없다.
- 3개의 좌표가 구해졌다면, `graph`배열을 깊은 복사 한 다음 그 복사한 배열에 3개의 좌표에 1을 할당하여 벽을 세운다.
  - 복사를 안 하고 기존 `graph`배열에 그대로 할당한다면, 벽을 세운 후 다음 경우의 수에도 그 벽이 남아있게 되어 문제가 된다.
  - `graph` 를 복사할때 주의할 점이, 스프레드 연산자로 `...graph`와 같이 하면 얕은 복사가 된다. 왜냐하면 graph는 2차원 배열이며, 스프레드 연산자는 얕은 복사를 하기 때문에 중첩된 배열은 복사가 안되어 `graph`에도 똑같이 할당되기 때문이다.
    - 그 이유는 얕은 복사를 하면 제일 상위 객체(배열도 객체다)의 참조값이 복사되지만, 그 참조값을 따라 갔을 때 중첩되어 있는 객체의 참조값은 두 객체 다 동일하게 한 중첩된 객체를 가리키기 때문이다.
  - 때문에 `graph.map(e=>[...e])` 와 같이 깊은 복사를 하여 중첩된 배열까지 전부 복사해준다.
- 벽을 세웠다면 이제 virus가 몇개의 빈 공간을 먹는지 구하는 함수 `checkNonVirus`에 복사한 그래프를 인자로 넘겨주며 호출한다.
```jsx
DFS()

function DFS(arr = [], visited = Array(empty.length).fill(0)){
    if(arr.length === 3){
        let fixedGraph = graph.map(e=>[...e])
        for(let i = 0; i < 3; i++){
            let [y, x] = arr[i]
            fixedGraph[y][x] = 1
        }
        checkNonVirus(fixedGraph)
        return
    }

    for(let i = 0; i < empty.length; i++){
        if(!visited[i]){
            arr.push(empty[i])
            visited[i] = 1
            DFS(arr, [...visited])
            arr.pop()
        }
    }

}
```

### 3. `checkNonVirus` 함수에서는 바이러스를 저장한 배열에서 바이러스 요소 하나씩 BFS함수를 호출하여 자기가 먹을 수 있는 빈 공간의 갯수를 구하여 answers 배열에 담는다.
- 이때 `visited` 배열을 통해 각 BFS에서 바이러스가 먹은 빈 공간을 방문처리 하여 중복으로 Count가 되지 않게 해준다.
```jsx
function checkNonVirus(fixedGraph){
    let count = 0
    const visited = Array.from(Array(N),()=> new Array(M).fill(0))
    for(let i = 0; i < virus.length; i++){
        let [y, x] = virus[i]
        if(!visited[y][x]){
            count += BFS(y, x, fixedGraph, visited)
        }
    }
    answers.push(count)
}
```

### 4. BFS 함수에서는 말 그대로 좌표 너비 우선 탐색을 한다.
- 이때 아래와 같이 인덱스를 0으로 초기값을 준 후 큐의 길이보다 작을때 까지 반복문을 돌며 반복문 마지막에서 1씩 증가시키면, 큐에서 그 인덱스 값이 곧 pop front가 된다.
  ```jsx
  let popIdx = 0;
  while(popIdx < queue.length){
      let [y,x] = queue[popIdx] // 이게 곧 pop front 이다.
      // ...
      popIdx++
  }
  ```
- 이 방법은 `shift()`로 popfront를 하는 방법 보다 훨씬 시간복잡도가 낮다. 왜냐하면 Shift는 맨 앞 요소를 pop 한 후, 뒤 요소들을 하나씩 앞으로 당기느라 O(n)의 시간 복잡도가 들지만, 위 방법은 그냥 인덱스에서 하나씩 참조하는 것이므로 O(1)의 시간 복잡도가 든다.
```jsx
function BFS(y,x, fixedGraph, visited){
    // 위 왼 아 오
    const dy = [-1, 0, 1, 0]
    const dx = [0, -1, 0, 1]
    visited[y][x] = 1
    const queue = [[y,x]]
    let popIdx = 0;
    let count = 0;
    while(popIdx < queue.length){
        let [y,x] = queue[popIdx]

        for(let i = 0; i < 4; i++){
            dirY = y + dy[i]
            dirX = x + dx[i]
            if(0 <= dirY && dirY < N && 0 <= dirX && dirX < M){
                if(fixedGraph[dirY][dirX] === 0 && !visited[dirY][dirX]){
                    visited[dirY][dirX] = 1
                    count++
                    queue.push([dirY,dirX])
                }
            }
        }
        popIdx++
    }
    return count
}
```

### 5. 마지막으로 `빈 공간 - 바이러스가 먹을 수 있는 빈 공간의 최솟값 - 3` 을 해준다.
- `answers` 배열은 바이러스가 먹을 수 있는 빈 공간의 갯수를 저장하고 있기 때문에 이 `answers`배열에서  최솟값을 reduce로 찾아 (Math.min 보다 메모리 효율적) 바이러스가 먹을 수 있는 빈 공간의 최솟값을 찾는다
- 거기다가 3을 빼주는 이유는, 우리는 벽 3개를 빈 공간에 세웠기 때문이다.
- 즉, `빈 공간 - 바이러스가 먹을 수 있는 빈 공간의 최솟값 - 3` = `얻을 수 있는 빈 공간(안전 영역) 크기의 최댓값` 이다.
```jsx
console.log(empty.length - answers.reduce((a,b)=>a>b?b:a) - 3)
```