### PR TITLE
[2024/05/12] 전성태_BFS

### DIFF
--- a/전성태/백준/구현/16234.js
+++ b/전성태/백준/구현/16234.js
@@ -1,0 +1,62 @@
+const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const [N, L, R] = stdin[0].split(' ').map(Number)
+const graph = Array(N)
+for(let i = 0; i < N; i++){
+    graph[i] = stdin[i + 1].split(' ').map(Number)
+}
+
+let day = 0
+while(true){
+    let visited = Array.from(Array(N),()=>Array(N).fill(0))
+    let flag = false
+    for(let y = 0; y < N; y++){
+        for(let x = 0; x < N; x++){
+            if(!visited[y][x]){
+                let [conRes, calcPeople] = BFS(y, x, visited)
+                if(conRes.length !== 1) {
+                    flag = true
+                    for(i of conRes){
+                        let [resY, resX] = i
+                        graph[resY][resX] = calcPeople
+                    }
+                }
+            }
+        }
+    }
+    if(!flag) break
+    day++
+}
+
+console.log(day)
+
+function BFS(startY, startX, visited){
+    const dy = [-1, 0, 1, 0]
+    const dx = [0, -1, 0, 1]
+    const queue = [[startY, startX]]
+    let connected = [[startY, startX]]
+    visited[startY][startX] = 1
+    let i = 0
+    let peopleSum = graph[startY][startX]
+    while(i < queue.length){
+        let [y, x] = queue[i]
+
+        for(let i = 0; i < 4; i++){
+            let dirY = y + dy[i]
+            let dirX = x + dx[i]
+            if(0 <= dirY && dirY < N && 0 <= dirX && dirX < N){
+                let difference = Math.abs(graph[dirY][dirX] - graph[y][x])
+                if(!visited[dirY][dirX]){
+                    if(L <= difference && difference <= R){
+                        queue.push([dirY,dirX])
+                        visited[dirY][dirX] = 1
+                        connected.push([dirY,dirX])
+                        peopleSum += graph[dirY][dirX]
+                    }
+                }
+            }
+        }
+        i++
+    }
+    return [connected,~~(peopleSum / connected.length)]
+}
+


### PR DESCRIPTION
# 인구 이동

> https://www.acmicpc.net/problem/16234

이 문제는 BFS를 이용하여 풀어야 한다.

### 1. 입력 받기
```jsx
const stdin = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
const [N, L, R] = stdin[0].split(' ').map(Number)
const graph = Array(N)
for(let i = 0; i < N; i++){
    graph[i] = stdin[i + 1].split(' ').map(Number)
}
```

### 2. 각 날짜별로 모든 지점에 대해 BFS탐색을 탐색을 하여 연합되는 지역을 구하며 인구 수를 갱신한다.
- 매일 모든 지역을 BFS 탐색 할 것이므로 매일 방문 배열을 초기화 해준다.
- BFS 탐색을 해도 인구 이동이 한번도 없었을 때 모든 인구이동이 끝난 상황이므로 이를 확인하기 위한 flag를 만든다.
  - 이 flag는 처음에는 `false` 값을 갖고 있다가 인구 이동이 한번이라도 이루어지면 `true`가 된다.
  - 그 날짜에 모든 지역을 BFS를 돌고 난 후, 이 flag가 `false`이면 더이상 인구 이동이 없는 것이므로 `break`를 한다.
    - 이 경우 총 걸린 날짜 수를 출력하고 프로그램을 종료한다.
- 각 지점에서 BFS를 돌면 `[conRes, calcPeople]` 이 리턴된다.
  - `conRes` : BFS를 탐색한 지역과 국경선을 공유하는(인구이동을 한) 지역을 담은 배열
  - `calcPeople` : 인구 이동 후 각 지역에 있을 사람의 수
- `conRes`배열의 길이가 1이 아닐 때, 즉 현재 지역 외에 국경선이 열려있는 경우, 인구 이동이 일어났기 때문에 인원 분배를해야 한다.
  - `conRes` 배열에 담긴 모든 지역의 사람 수를 `calcPeople`로 대입한다.
```jsx
let day = 0
while(true){
    let visited = Array.from(Array(N),()=>Array(N).fill(0))
    let flag = false
    for(let y = 0; y < N; y++){
        for(let x = 0; x < N; x++){
            if(!visited[y][x]){
                let [conRes, calcPeople] = BFS(y, x, visited)
                if(conRes.length !== 1) {
                    flag = true
                    for(i of conRes){
                        let [resY, resX] = i
                        graph[resY][resX] = calcPeople
                    }
                }
            }
        }
    }
    if(!flag) break
    day++
}

console.log(day)
```

### 3. BFS 구현
- BFS 탐색 전에 시작 지점을 
  - `큐`, 연결되어 있는 도시 목록 `connected`에 담고 
  - 방문 배열 `visited` 에 방문 처리를 하고
  - 연결되어 있는 총 인구수를 저장할 `peopleSum` 변수에  현재 도시의 인원을 저장한다.
- 위, 왼쪽, 아래, 오른쪽에 대해 각각 BFS를 돌며
  - 그래프 범위 안에 있고
    - 인구수 차이가 `L`이상 `R` 이하인 지역에 대해
      - 큐에 넣고
      - 방문처리 후
      - 연결된 도시 배열 `connected`에 push 후
      - 연결되어 있는 총 인구수를 저장할 `peopleSum` 변수에 인구 수를 갱신 한다.
- BFS 탐색이 끝나면 `connected` 배열과 인구 이동 후 각 지역에 있을 사람의 수를 계산한 값을 배열에 담아 리턴한다.
```jsx
function BFS(startY, startX, visited){
    const dy = [-1, 0, 1, 0]
    const dx = [0, -1, 0, 1]
    const queue = [[startY, startX]]
    let connected = [[startY, startX]]
    visited[startY][startX] = 1
    let i = 0
    let peopleSum = graph[startY][startX]
    while(i < queue.length){
        let [y, x] = queue[i]

        for(let i = 0; i < 4; i++){
            let dirY = y + dy[i]
            let dirX = x + dx[i]
            if(0 <= dirY && dirY < N && 0 <= dirX && dirX < N){
                let difference = Math.abs(graph[dirY][dirX] - graph[y][x])
                if(!visited[dirY][dirX]){
                    if(L <= difference && difference <= R){
                        queue.push([dirY,dirX])
                        visited[dirY][dirX] = 1
                        connected.push([dirY,dirX])
                        peopleSum += graph[dirY][dirX]
                    }
                }
            }
        }
        i++
    }
    return [connected,~~(peopleSum / connected.length)]
}
```